### PR TITLE
Hotfix: Add SLJ news item and press

### DIFF
--- a/about.html
+++ b/about.html
@@ -160,6 +160,10 @@
       <div class="content-section-description">
         Read what people are saying about ScratchJr.
       </div>
+      <div class="content-description-answer"><a href="http://www.slj.com/2016/12/reviews/best-of/top-10-tech-2016/">Top 10 Tech | 2016</a> - School Library Journal. December 6, 2016</div>
+      <div class="content-description-answer"><a href="https://youtu.be/Zo57R4f0_9Q">Book review of the Official ScratchJr Book</a> - Phil Shapiro (video review). January 31, 2016</div>
+      <div class="content-description-answer"><a href="https://geekdad.com/2016/01/scratchjr-book-gets-younger/">This ScratchJr Book Gets Younger Minds Creating with Code</a> - GeekDad. January 7, 2016</div>
+      <div class="content-description-answer"><a href="http://www.npr.org/sections/ed/2015/09/18/441122285/learning-to-code-in-preschool">Coding Class, Then Naptime: Computer Science For The Kindergarten Set</a> - NPR. September 18,2015</div>
       <div class="content-description-answer"><a href="http://www.forbes.com/sites/jordanshapiro/2015/06/30/your-kids-can-learn-to-code-during-summer-vacation/">How Your Kids Can Learn To Code During Summer Vacation</a> - Forbes. June 30, 2015</div>
       <div class="content-description-answer"><a href="http://yourniskayuna.com/blog/2015/04/23/birchwood-elementary-students-first//">First graders give grown-ups programming lesson</a> - Your Niskayuna. April 23, 2015</div>
       <div class="content-description-answer"><a href="http://cacm.acm.org/news/183337-bringing-coding-to-kindergarten/fulltext/">Bringing Coding to Kindergarten</a> - ACM News. February 17, 2015</div>

--- a/index.html
+++ b/index.html
@@ -114,11 +114,13 @@
         News
       </div>
       <div class="content-news-body">
-        Celebrate Computer Science Education week with these
-        <a href="hoc.html">ScratchJr activities</a>
-        and check out some fun ScratchJr <a href="https://ase.tufts.edu/devtech/CSEdWeek2016.html">Activity Videos</a>
-        from the DevTech Research Group at Tufts.
+          ScratchJr was named one of the
+          <a href="http://www.slj.com/2016/12/reviews/best-of/top-10-tech-2016/">
+              Top 10 Tech</a> by School Library Journal.
       </div>
+      <div class="content-news-body">
+      Check out some fun ScratchJr <a href="https://ase.tufts.edu/devtech/CSEdWeek2016.html">Activity Videos</a>
+      from the DevTech Research Group at Tufts.</div>
       <div class="content-news-body">
         ScratchJr is now available in more languages!
       </div>


### PR DESCRIPTION
Fixes #39 

* Adds School Library Journal news item on the index page
* Adds School Library Journal and a couple of other reviews to the About#Press page
* Takes out the link to the HOC page, but keeps the link to the Tufts Jumbo learns to code page.
