### PR TITLE
Add redirects to routes.json to handle legacy urls

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -5,35 +5,39 @@
 		"title": "Home"
 	},
 	{
+		"pattern": "^/about\\.html",
+		"name": "about-redirect",
+		"redirect": "/about"
+	},
+	{
 		"pattern": "^/about(/.+)*/?",
 		"name": "about",
 		"title": "About"
 	},
 	{
-		"pattern": "^/about\\.html(#.*)$",
-		"name": "about-redirect",
-		"redirect": "/about"
+		"pattern": "^/learn\\.html",
+		"name": "learn-redirect",
+		"redirect": "/learn"
 	},
 	{
 		"pattern": "^/learn(/.+)*/?",
 		"name": "learn",
 		"title": "Learn"
-	},
-	
+	},	
 	{
-		"pattern": "^/learn\\.html(#.*)$",
-		"name": "learn-redirect",
-		"redirect": "/learn"
+		"pattern": "^/teach\\.html",
+		"name": "teach-redirect",
+		"redirect": "/teach"
 	},
 	{
 		"pattern": "^/teach(/.+)*/?",
 		"name": "teach",
 		"title": "Teach"
-	},	
+	},
 	{
-		"pattern": "^/teach\\.html(#.*)$",
-		"name": "teach-redirect",
-		"redirect": "/teach"
+		"pattern": "^/donate\\.html",
+		"name": "donate-redirect",
+		"redirect": "/donate"
 	},
 	{
 		"pattern": "^/donate/?$",
@@ -41,9 +45,9 @@
 		"title": "Donate"
 	},
 	{
-		"pattern": "^/donate\\.html(#.*)$",
-		"name": "donate-redirect",
-		"redirect": "/donate"
+		"pattern": "^/privacy\\.html",
+		"name": "privacy-redirect",
+		"redirect": "/privacy"
 	},
 	{
 		"pattern": "^/privacy/?$",
@@ -51,23 +55,18 @@
 		"title": "Privacy"
 	},
 	{
-		"pattern": "^/privacy\\.html(#.*)$",
-		"name": "privacy-redirect",
-		"redirect": "/privacy"
-	},
-	{
 		"pattern": "^/hoc/?$",
 		"name": "hoc",
 		"title": "Hour of Code"
 	},
 	{
+		"pattern": "^/eula\\.html",
+		"name": "eula-redirect",
+		"redirect": "/eula"
+	},
+	{
 		"pattern": "^/eula/?$",
 		"name": "eula",
 		"title": "Terms and Conditions"
-	},
-	{
-		"pattern": "^/eula\\.html(#.*)$",
-		"name": "eula-redirect",
-		"redirect": "/eula"
 	}
 ]


### PR DESCRIPTION
Because of the overlap between the redirects and rewrite (`/about` also matches `/about\.html`) the redirect needs to come first for all routes
