### PR TITLE
Allow main menu to change sizes based on language

### DIFF
--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -17,20 +17,21 @@ $nav-selected-color: #0a7199;
 }
 
 #header-nav {
+    display: flex;
     position: relative;
+    justify-content: space-around;
     float: right;
+    width: 700px;
 }
 
 .header-nav-item-wrapper {
-    float: left;
+    flex: 1 0 auto;
 }
 
 .header-nav-item {
-    float: left;
     padding-top: 23px;
-    padding-right: 35px;
-    padding-left: 35px;
     height: 35px;
+    text-align: center;
     letter-spacing: 1px;
     color: $nav-text-color;
     font-family: "Lucida Grande", arial, sans-serif;


### PR DESCRIPTION
Fixes #85.

Instead of having a fixed padding between navbar items use flexbox to have them grow based on content and space available.

This should work for all the currently translated languages. We may need to style based on lang attribute for any that are more extreme.

Testing: (https://staging.scratchjr.org)
- [ ] Main navigation should not overflow on to two lines when switching languages
