### PR TITLE
Fix Tufts content issues

### DIFF
--- a/src/views/outreach/host/home.jsx
+++ b/src/views/outreach/host/home.jsx
@@ -24,15 +24,8 @@ const HostHomeSection = () => (
                 the research portion of ScratchJr
                 Family Days, though it is not
                 mandatory for running a ScratchJr family event.
-                Should you wish to participate, please sign up by filling out a {' '}
-                    <a
-                        href="https://goo.gl/forms/h1LWQWPOZ8azHNAt2"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                            short questionaire
-                    </a>.
-                We appreciate your feedback!</p>
+                Should you wish to participate, please sign up by filling out a
+                short questionnaire below. We appreciate your feedback!</p>
             </div>
         </div>
         

--- a/src/views/outreach/news.jsx
+++ b/src/views/outreach/news.jsx
@@ -12,6 +12,14 @@ const NewsSection = () => (
         <div className="content-section-description">
             See what other people are doing in their Family Days.
         </div>
+        <div className="content-section-description">
+            Tweet your Family Day news with the hashtag #ScratchJrFamily<br />
+            <a href=" https://twitter.com/intent/tweet?screen_name=ScratchJr&hashtags=ScratchJrFamily">
+                <div className="blue-button">
+                    Tweet #ScratchJrFamily
+                </div>
+            </a>
+        </div>
         <div className="fd-news-feed">
             <Timeline
                 dataSource={{

--- a/src/views/teach/assessments/student_answer_sheet.html
+++ b/src/views/teach/assessments/student_answer_sheet.html
@@ -56,7 +56,7 @@
 							<p>Querstion 3:</p>
 							<img src="images/answersheet/image013.png">
 							<div class="page-break"></div>
-							<p><b>Category: Match the program</b></p>
+							<p><b>Category: Reverse Engineering</b></p>
 							<p>Question 1:</p>
 							<br><br><br><br><br><br><br><br><br><br><br><br>
 							<p>Question 2:</p>


### PR DESCRIPTION
- outreach/host: take out link to questionnaire as it is embedded below
- outreach/news: Add call to action with tweet button
- solve-it/student answer sheet: change dup ‘Category: Match the program’ to ‘Category: Reverse Engineering’

fixes #94 - Feedback from Tufts on the staging version of the ScratchJr website
