### PR TITLE
Fixing family-days form problems

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -70,6 +70,11 @@
 		"title": "Hour of Code"
 	},
 	{
+		"pattern": "^/familydays/?$",
+		"name": "familydays",
+		"title": "Family Days"
+	},
+	{
 		"pattern": "^/eula\\.html",
 		"name": "eula-redirect",
 		"redirect": "/eula"

--- a/src/views/familydays/familydays.jsx
+++ b/src/views/familydays/familydays.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {render} from 'react-dom';
+import htmlContent from '../outreach/host/family-days.html';
+import '../outreach/host/family-days.css';
+import '../../components/sectionitem/sectionitem.scss';
+
+const FamilyDays = () => (
+    <div
+        id="content"
+        dangerouslySetInnerHTML={{__html: htmlContent}} // eslint-disable-line react/no-danger
+    />
+);
+
+render(
+    <FamilyDays />,
+    document.getElementById('app'));

--- a/src/views/outreach/host/home.jsx
+++ b/src/views/outreach/host/home.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 class HostHomeSection extends React.Component {
-    componentDidMount () {
-        const ifr = this.ifr;
+    scrollIframeOnLoad (ifr) {
         ifr.addEventListener('load',
             () => {
                 window.scrollTo(0, 0);
@@ -39,9 +38,7 @@ class HostHomeSection extends React.Component {
                 </div>
                 
                 <iframe
-                    ref={c => { 
-                        this.ifr = c; 
-                    }}
+                    ref={this.scrollIframeOnLoad}
                     src="https://docs.google.com/forms/d/e/1FAIpQLSd1I1N3ayxldpnDz2CBWa8KFRuZ5XB1yqz5PPC96dFd9qhTiA/viewform?embedded=true"
                     width="900"
                     height="2000"

--- a/src/views/outreach/host/home.jsx
+++ b/src/views/outreach/host/home.jsx
@@ -1,44 +1,58 @@
 import React from 'react';
 
-const HostHomeSection = () => (
-    <div>
-        <div className="content-section">
-            <div className="content-section-description">
-                <p>{'The '}
-                    <a
-                        href="http://ase.tufts.edu/devtech/index.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        DevTech Research Group
-                    </a>{ ' at ' }
-                    <a
-                        href="https://www.tufts.edu/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Tufts University
-                    </a>,
-                co-creator of ScratchJr, is conducting a study about how families
-                learn programming together. We would like to invite you to participate in
-                the research portion of ScratchJr
-                Family Days, though it is not
-                mandatory for running a ScratchJr family event.
-                Should you wish to participate, please sign up by filling out a
-                short questionnaire below. We appreciate your feedback!</p>
+class HostHomeSection extends React.Component {
+    componentDidMount () {
+        const ifr = this.ifr;
+        ifr.addEventListener('load',
+            () => {
+                window.scrollTo(0, 0);
+            });
+    }
+    render () {
+        return (
+            <div>
+                <div className="content-section">
+                    <div className="content-section-description">
+                        <p>{'The '}
+                            <a
+                                href="http://ase.tufts.edu/devtech/index.html"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                DevTech Research Group
+                            </a>{ ' at ' }
+                            <a
+                                href="https://www.tufts.edu/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Tufts University
+                            </a>,
+                        co-creator of ScratchJr, is conducting a study about how families
+                        learn programming together. We would like to invite you to participate in
+                        the research portion of ScratchJr
+                        Family Days, though it is not
+                        mandatory for running a ScratchJr family event.
+                        Should you wish to participate, please sign up by filling out a
+                        short questionnaire below. We appreciate your feedback!</p>
+                    </div>
+                </div>
+                
+                <iframe
+                    ref={c => { 
+                        this.ifr = c; 
+                    }}
+                    src="https://docs.google.com/forms/d/e/1FAIpQLSd1I1N3ayxldpnDz2CBWa8KFRuZ5XB1yqz5PPC96dFd9qhTiA/viewform?embedded=true"
+                    width="900"
+                    height="2000"
+                    frameBorder="0"
+                    marginHeight="0"
+                    marginWidth="0"
+                >
+                    Loading...
+                </iframe>
             </div>
-        </div>
-        
-        <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLSd1I1N3ayxldpnDz2CBWa8KFRuZ5XB1yqz5PPC96dFd9qhTiA/viewform?embedded=true"
-            width="900"
-            height="2000"
-            frameBorder="0"
-            marginHeight="0"
-            marginWidth="0"
-        >
-            Loading...
-        </iframe>
-    </div>
-);
+        );
+    }
+}
 export default HostHomeSection;

--- a/src/views/outreach/outreach.jsx
+++ b/src/views/outreach/outreach.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {BrowserRouter, Redirect, Route, Switch} from 'react-router-dom';
+import ScrollManager from '../../components/scrollmanager/scrollmanager.jsx';
 import NavBar from '../../components/navbar/navbar.jsx';
 import Footer from '../../components/footer/footer.jsx';
 import TabNav from '../../components/tabnav/tabnav.jsx';
@@ -33,35 +34,37 @@ const Outreach = () => {
     ];
     return (
         <BrowserRouter basename="/outreach">
-            <div>
-                <NavBar selected="outreach" />
-                <div id="content">
-                    <TabNav items={tabs} />
-                    <Switch>
-                        <Redirect
-                            exact
-                            from="/"
-                            to="/about"
-                        />
-                        <Route
-                            path="/about"
-                            component={AboutSection}
-                        />
-                        <Route
-                            path="/host"
-                            component={HostSection}
-                        />
-                        <Route
-                            path="/news"
-                            component={NewsSection}
-                        />
-                        <Route
-                            component={PageNotFound}
-                        />
-                    </Switch>
+            <ScrollManager basename="/outreach">
+                <div>
+                    <NavBar selected="outreach" />
+                    <div id="content">
+                        <TabNav items={tabs} />
+                        <Switch>
+                            <Redirect
+                                exact
+                                from="/"
+                                to="/about"
+                            />
+                            <Route
+                                path="/about"
+                                component={AboutSection}
+                            />
+                            <Route
+                                path="/host"
+                                component={HostSection}
+                            />
+                            <Route
+                                path="/news"
+                                component={NewsSection}
+                            />
+                            <Route
+                                component={PageNotFound}
+                            />
+                        </Switch>
+                    </div>
+                    <Footer />
                 </div>
-                <Footer />
-            </div>
+            </ScrollManager>
         </BrowserRouter>
     );
 };


### PR DESCRIPTION
* Added a new view (and route) that reuses the family-days content without the rest of the header footer so that it can be referenced in the iframe confirmation. (This seems like rather a brute force way to solve the issue that google forms don't let you open links in a new tab/window. I'd love to hear there's a more elegant solution)
* Added onLoad handler for the iframe to reset the window to the top when the iframe loads.