### PR TITLE
Check for null iframe

### DIFF
--- a/src/views/outreach/host/home.jsx
+++ b/src/views/outreach/host/home.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 class HostHomeSection extends React.Component {
     scrollIframeOnLoad (ifr) {
-        ifr.addEventListener('load',
-            () => {
-                window.scrollTo(0, 0);
-            });
+        if (ifr !== null) {
+            ifr.addEventListener('load',
+                () => {
+                    window.scrollTo(0, 0);
+                });
+        }
     }
     render () {
         return (


### PR DESCRIPTION
If the person doesn’t submit the form (iframe), but just clicks back to about or news, the iframe is null, so don’t try to attach the load handler.

resolves #122 