### PR TITLE
Greenkeeper/eslint plugin react 7.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^4.4.1",
     "eslint-config-scratch": "^5.0.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-react": "^7.2.1",
+    "eslint-plugin-react": "^7.5.1",
     "express": "4.15.4",
     "fastly": "2.2.0",
     "file-loader": "^1.0.0",

--- a/src/views/about/info.jsx
+++ b/src/views/about/info.jsx
@@ -137,9 +137,12 @@ const InfoSection = () => (
                 </div>
 
                 <div className="content-description-answer">
-                    <span>Other supporters from the ScratchJr Kickstarter
-                        campaign:</span> <span className="notranslate">Aaron Suggs, Abe Stein,
-                        Abinash Bishoyi, Adam Bellow,
+                    <span>
+                        Other supporters from the ScratchJr Kickstarter
+                        campaign:
+                    </span>
+                    <span className="notranslate">
+                        Aaron Suggs, Abe Stein, Abinash Bishoyi, Adam Bellow,
                         Adam Skylar Miner, Adriana Moscatelli, Adrienne Tilley, Agnes Wagenh&auml;user
                         Aidan Raney, Aiden &amp; Eryn Murphy, Akim Boyko, Akinsola Akinbiyi,
                         Alain-Christian, Albert Oldfield, Alex Abdugafarov, Alexander &amp; Edward Grabon,
@@ -260,10 +263,7 @@ const InfoSection = () => (
                         V.R. Bones, Andrew Walton, Wayne Blackburn, Wendy E. Rowe, Will Ober, William
                         Bettridge-Radford, William Wnekowicz, Wincent Balin, Xose P&eacute;rez, Yannick
                         Methot, Yeou-Hsiang Cheng, Yoojin Lim, Yoshihiro Kawahara, Yrjan Tangenes, Zachary
-                        Kestenbaum, Zack Chapple, Z&eacute;bulon Grav&eacute;, Zoe Franklyn,
-                        &amp; 141Learning.
-                    </span>
-
+                        Kestenbaum, Zack Chapple, Z&eacute;bulon Grav&eacute;, Zoe Franklyn, &amp; 141Learning.</span>
                 </div>
             </div>
 


### PR DESCRIPTION
An eslint update broke the build. Reformatting the info.jsx file fixed the indentation error.