### PR TITLE
chore(package): update slick-carousel to version 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rrc": "0.10.1",
     "sass-lint": "^1.11.1",
     "sass-loader": "^6.0.6",
-    "slick-carousel": "1.7.1",
+    "slick-carousel": "1.8.1",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.9",
     "webpack": "^3.5.5",


### PR DESCRIPTION
Closes #103 from oct 3