### PR TITLE
Update scratchjr connect link

### DIFF
--- a/src/views/teach/connect/home.jsx
+++ b/src/views/teach/connect/home.jsx
@@ -27,7 +27,7 @@ const ConnectHome = () => (
 
         <div className="connect-block">
             <a
-                href="https://scratchjrconnect.tufts.edu/"
+                href="https://connect.scratchjr.org/"
                 id="connect-button"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
We have switched ScratchJr Cconnect over to a Scratch foundation site hosted at connect.scratchjr.org.

Testing:

- [ ] the button on https://www.scratchjr.org/teach/connect goes to connect.scratchjr.org not a tufts.edu site.