### PR TITLE
Build and test PRs without requiring deploy access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,32 +1,68 @@
 name: Build and Deploy ScratchJr Website
 
 on:
-    push:
+  push:
+    branches: [develop, master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-    build-and-deploy:
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write
-            contents: write
-        environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
-        steps:
-        - uses: actions/checkout@v4
-        - name: Use Node 17x
-          uses: actions/setup-node@v4
-          with:
-            node-version: '17.x'
-        - name: Install Dependencies
-          run: npm ci --legacy-peer-deps
-        - name: Lint Site Code
-          run: npm run test
-        - name: Build Site
-          run: npm run build
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
-            role-session-name: GitHub-Action-Role
-            aws-region: ${{ vars.AWS_REGION }}
-        - name: Upload to S3
-          run: |
-                aws s3 sync ./build s3://${{ vars.AWS_S3_BUCKET }}/junior/
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node 17x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '17.x'
+      - name: Install Dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Lint Site Code
+        run: make lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node 17x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '17.x'
+      - name: Install Dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Build Site
+        run: npm run build
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+          retention-days: 1
+
+  deploy:
+    needs: [lint, build]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
+    steps:
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build/
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          role-session-name: GitHub-Action-Role
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Upload to S3
+        run: |
+          aws s3 sync ./build s3://${{ vars.AWS_S3_BUCKET }}/junior/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
         - uses: actions/checkout@v4
         - name: Use Node 17x
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@v4
           with:
             node-version: '17.x'
         - name: Install Dependencies


### PR DESCRIPTION
### Resolves

_No associated GitHub issue; this is an internal CI configuration change to the deploy workflow._

### Proposed Changes

Splits the single `build-and-deploy` job into three jobs:

- `lint` runs `make lint` (eslint + sass-lint).
- `build` runs the webpack build and uploads the result as an artifact.
- `deploy` downloads that artifact, assumes the AWS OIDC role, and syncs to S3. It carries the `environment` (production for `master`, otherwise staging) and only runs on `push` and `workflow_dispatch`.

`lint` and `build` run on `pull_request` (including from forks) and need no environment or AWS credentials, so any PR builds and tests. Only pushes to `develop`/`master` and manual `workflow_dispatch` runs deploy.

Also:

- `lint` and `build` are independent, so a lint failure no longer blocks the build and vice versa.
- `push` is scoped to `develop` and `master`, with a `cancel-in-progress` concurrency group, removing duplicate runs and keeping last-push-wins.
- `workflow_dispatch` allows deploying a branch on demand. Any branch other than `master` deploys to staging; dispatching from `master` deploys to production, matching the `environment` selection used for pushes.

### Reason for Changes

Previously the workflow ran on every push to any branch and did everything in one job that required the deployment environment and AWS credentials. PRs that cannot access the environment (notably from forks) could not build or test, and every branch push deployed to staging, overwriting whatever was there.

### Test Coverage

This is a CI workflow change. Verification steps after merge:

- Open a PR and confirm `lint` and `build` run and report independently, with no `deploy` job.
- Push to `develop` and confirm `lint`, `build`, then `deploy` to staging.
- Run `workflow_dispatch` on a feature branch and confirm it deploys to staging.