### PR TITLE
build: migrate Fastly config script to the official fastly-js client

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -1,82 +1,62 @@
-var promisify = require('util').promisify;
-var defaults = require('lodash.defaults');
+const defaults = require('lodash.defaults');
 
-var route_json = require('../src/routes.json');
+const routeJson = require('../src/routes.json');
 
 const FASTLY_SERVICE_ID = process.env.FASTLY_SERVICE_ID || '';
 const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME || '';
 const BUCKET_NAME_HEADER_NAME = 'Bucket name';
 
-var fastly = require('./lib/fastly-extended')(process.env.FASTLY_API_KEY, FASTLY_SERVICE_ID);
-
-// The fastly-extended helpers are callback-style; promisify the ones we use.
-var getLatestVersion = promisify(fastly.getLatestVersion.bind(fastly));
-var cloneVersion = promisify(fastly.cloneVersion.bind(fastly));
-var setCondition = promisify(fastly.setCondition.bind(fastly));
-var setFastlyHeader = promisify(fastly.setFastlyHeader.bind(fastly));
-var setResponseObject = promisify(fastly.setResponseObject.bind(fastly));
-var activateVersion = promisify(fastly.activateVersion.bind(fastly));
-var purgeAll = promisify(fastly.purgeAll.bind(fastly));
+const fastly = require('./lib/fastly-extended')(process.env.FASTLY_API_KEY, FASTLY_SERVICE_ID);
 
 /*
  * Translate an express-style pattern e.g. /path/:arg/ to a regex
  * all :arguments become .+?
  */
-var expressPatternToRegex = function (pattern) {
-    return pattern.replace(/(:[^/]+)/gi, '.+?');
+const expressPatternToRegex = pattern => pattern.replace(/(:[^/]+)/gi, '.+?');
+
+const getConditionNameForRoute = (route, type) => `routes/${route.pattern} (${type})`;
+
+const getHeaderNameForRoute = route => {
+    if (route.name) return `rewrites/${route.name}`;
+    if (route.redirect) return `redirects/${route.pattern}`;
 };
 
-var getConditionNameForRoute = function (route, type) {
-    return 'routes/' + route.pattern + ' (' + type + ')';
-};
+const getResponseNameForRoute = route => `redirects/${route.pattern}`;
 
-var getHeaderNameForRoute = function (route) {
-    if (route.name) return 'rewrites/' + route.name;
-    if (route.redirect) return 'redirects/' + route.pattern;
-};
-
-var getResponseNameForRoute = function (route) {
-    return 'redirects/' + route.pattern;
-};
-
-var routes = route_json.map(function (route) {
-    return defaults({}, {pattern: expressPatternToRegex(route.pattern)}, route);
-});
+const routes = routeJson.map(route => defaults({}, {pattern: expressPatternToRegex(route.pattern)}, route));
 
 // Get the latest version, cloning it first if it is already active or locked.
-var getWorkingVersion = async function () {
-    var response = await getLatestVersion();
+const getWorkingVersion = async () => {
+    const response = await fastly.getLatestVersion();
     if (response.active || response.locked) {
-        var cloned;
+        let cloned;
         try {
-            cloned = await cloneVersion(response.number);
+            cloned = await fastly.cloneVersion(response.number);
         } catch (err) {
-            throw new Error('Failed to clone latest version: ' + err);
+            throw new Error(`Failed to clone latest version: ${err}`);
         }
         return cloned.number;
     }
     return response.number;
 };
 
-var setBucketNameHeader = function (version) {
-    return setFastlyHeader(version, {
-        name: BUCKET_NAME_HEADER_NAME,
-        action: 'set',
-        ignore_if_set: 0,
-        type: 'REQUEST',
-        dst: 'http.host',
-        src: '"' + S3_BUCKET_NAME + '"',
-        priority: 1
-    });
-};
+const setBucketNameHeader = version => fastly.setFastlyHeader(version, {
+    name: BUCKET_NAME_HEADER_NAME,
+    action: 'set',
+    ignore_if_set: 0,
+    type: 'REQUEST',
+    dst: 'http.host',
+    src: `"${S3_BUCKET_NAME}"`,
+    priority: 1
+});
 
 // Create a request condition per route and return them keyed by route index.
-var setAppRouteRequestConditions = async function (version) {
-    var conditions = [];
-    await Promise.all(routes.map(async function (route, id) {
-        conditions[id] = await setCondition(version, {
+const setAppRouteRequestConditions = async version => {
+    const conditions = [];
+    await Promise.all(routes.map(async (route, id) => {
+        conditions[id] = await fastly.setCondition(version, {
             name: getConditionNameForRoute(route, 'request'),
-            statement: 'req.url ~ "' + route.pattern + '"',
+            statement: `req.url ~ "${route.pattern}"`,
             type: 'REQUEST',
             // Priority needs to be > 1 to not interact with http->https redirect
             priority: 10 + id
@@ -85,58 +65,54 @@ var setAppRouteRequestConditions = async function (version) {
     return conditions;
 };
 
-var setRedirectRouteHeader = async function (version, route, id) {
-    var responseCondition = await setCondition(version, {
+const setRedirectRouteHeader = async (version, route, id) => {
+    const responseCondition = await fastly.setCondition(version, {
         name: getConditionNameForRoute(route, 'response'),
-        statement: 'req.url ~ "' + route.pattern + '"',
+        statement: `req.url ~ "${route.pattern}"`,
         type: 'RESPONSE',
         priority: id
     });
-    await setResponseObject(version, {
+    await fastly.setResponseObject(version, {
         name: getResponseNameForRoute(route),
         status: 301,
         response: 'Moved Permanently',
         request_condition: getConditionNameForRoute(route, 'request')
     });
-    return setFastlyHeader(version, {
+    return fastly.setFastlyHeader(version, {
         name: getHeaderNameForRoute(route),
         action: 'set',
         ignore_if_set: 0,
         type: 'RESPONSE',
         dst: 'http.Location',
-        src: '"' + route.redirect + '"',
+        src: `"${route.redirect}"`,
         response_condition: responseCondition.name
     });
 };
 
-var setRewriteRouteHeader = function (version, route, requestCondition) {
-    return setFastlyHeader(version, {
-        name: getHeaderNameForRoute(route, 'request'),
-        action: 'set',
-        ignore_if_set: 0,
-        type: 'REQUEST',
-        dst: 'url',
-        src: '"/' + route.name + '.html"',
-        request_condition: requestCondition.name,
-        priority: 10
-    });
-};
+const setRewriteRouteHeader = (version, route, requestCondition) => fastly.setFastlyHeader(version, {
+    name: getHeaderNameForRoute(route, 'request'),
+    action: 'set',
+    ignore_if_set: 0,
+    type: 'REQUEST',
+    dst: 'url',
+    src: `"/${route.name}.html"`,
+    request_condition: requestCondition.name,
+    priority: 10
+});
 
 // Create the response/request header for every route (redirects vs. rewrites).
-var setAppRouteHeaders = function (version, requestConditions) {
-    return Promise.all(routes.map(function (route, id) {
-        if (route.redirect) {
-            return setRedirectRouteHeader(version, route, id);
-        }
-        return setRewriteRouteHeader(version, route, requestConditions[id]);
-    }));
-};
+const setAppRouteHeaders = (version, requestConditions) => Promise.all(routes.map((route, id) => {
+    if (route.redirect) {
+        return setRedirectRouteHeader(version, route, id);
+    }
+    return setRewriteRouteHeader(version, route, requestConditions[id]);
+}));
 
-var configureFastly = async function () {
-    var version = await getWorkingVersion();
+const configureFastly = async () => {
+    const version = await getWorkingVersion();
     // The bucket header and the request conditions depend only on the version,
     // so run them together; the route headers depend on the request conditions.
-    var results = await Promise.all([
+    const results = await Promise.all([
         setBucketNameHeader(version),
         setAppRouteRequestConditions(version)
     ]);
@@ -145,14 +121,14 @@ var configureFastly = async function () {
 };
 
 configureFastly()
-    .then(async function (version) {
+    .then(async version => {
         if (!process.env.FASTLY_ACTIVATE_CHANGES) return;
-        var response = await activateVersion(version);
-        process.stdout.write('Successfully configured and activated version ' + response.number + '\n');
-        await purgeAll(FASTLY_SERVICE_ID);
+        const response = await fastly.activateVersion(version);
+        process.stdout.write(`Successfully configured and activated version ${response.number}\n`);
+        await fastly.purgeAll(FASTLY_SERVICE_ID);
         process.stdout.write('Purged all.\n');
     })
-    .catch(function (err) {
-        process.stderr.write((err && err.stack ? err.stack : err) + '\n');
+    .catch(err => {
+        process.stderr.write(`${err && err.stack ? err.stack : err}\n`);
         process.exit(1);
     });

--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -1,170 +1,110 @@
-var Fastly = require('fastly');
+const Fastly = require('fastly');
 
 /*
- * Fastly library extended to allow configuration for a particular service
- * and some helper methods.
+ * Fastly configuration helpers built on the official fastly-js client.
  *
- * @param {string} API key
- * @param {string} Service id
+ * Wraps the per-resource API classes and exposes Promise-returning, upsert-by-
+ * name helpers with stable signatures so callers don't deal with the client's
+ * create-vs-update split. Authenticates the shared ApiClient on construction.
+ *
+ * @param {string} apiToken Fastly API token
+ * @param {string} serviceId Fastly service id
  */
-module.exports = function (apiKey, serviceId) {
-    var fastly = Fastly(apiKey);
-    fastly.serviceId = serviceId;
+module.exports = (apiToken, serviceId) => {
+    Fastly.ApiClient.instance.authenticate(apiToken);
 
-    /*
-     * Helper method for constructing Fastly API urls
-     *
-     * @param {string} Service id
-     * @param {number} Version
-     *
-     * @return {string}
-     */
-    fastly.getFastlyAPIPrefix = function (serviceId, version) {
-        return '/service/' + encodeURIComponent(serviceId) + '/version/' + version;
-    };
+    const versionApi = new Fastly.VersionApi();
+    const conditionApi = new Fastly.ConditionApi();
+    const headerApi = new Fastly.HeaderApi();
+    const responseObjectApi = new Fastly.ResponseObjectApi();
+    const purgeApi = new Fastly.PurgeApi();
 
-    /*
-     * getLatestVersion: Get the most recent version for the configured service
-     *
-     * @param {callback} Callback with signature *err, latestVersion)
-     */
-    fastly.getLatestVersion = function (cb) {
-        if (!this.serviceId) {
-            return cb('Failed to get latest version. No serviceId configured');
-        }
-        var url = '/service/'+ encodeURIComponent(this.serviceId) +'/version';
-        this.request('GET', url, function (err, versions) {
-            if (err) {
-                return cb('Failed to fetch versions: ' + err);
+    // Upsert-by-name: fastly-js has no upsert, so update (PUT by name) and fall
+    // back to create (POST) when the resource does not yet exist (404).
+    const upsert = (update, create) => update().catch(err => {
+        if (err && err.status === 404) return create();
+        throw err;
+    });
+
+    const withService = (version, extra) => Object.assign(
+        {service_id: serviceId, version_id: version},
+        extra
+    );
+
+    return {
+        serviceId: serviceId,
+
+        // Get the most recent version for the service.
+        getLatestVersion: () => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to get latest version. No serviceId configured'));
             }
-            var latestVersion = versions.reduce(function (latestVersion, version) {
-                if (!latestVersion) return version;
-                if (version.number > latestVersion.number) return version;
-                return latestVersion;
-            });
-            return cb(null, latestVersion);
-        });
-    };
+            return versionApi.listServiceVersions({service_id: serviceId})
+                .then(versions => versions.reduce((latest, version) => {
+                    if (!latest) return version;
+                    if (version.number > latest.number) return version;
+                    return latest;
+                }));
+        },
 
-    /*
-     * setCondition: Upsert a Fastly condition entry
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Condition object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setCondition = function (version, condition, cb) {
-        if (!this.serviceId) {
-            return cb('Failed to set condition. No serviceId configured');
-        }
-        var name = condition.name;
-        var putUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/condition/' + encodeURIComponent(name);
-        var postUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/condition';
-        return this.request('PUT', putUrl, condition, function (err, response) {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, condition, function (err, response) {
-                    if (err) {
-                        return cb('Failed while inserting condition \"' + condition.statement + '\": ' + err);
-                    }
-                    return cb(null, response);
-                });
-                return;
+        // Clone a version to create a new, editable version.
+        cloneVersion: version => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to clone version. No serviceId configured.'));
             }
-            if (err) {
-                return cb('Failed to update condition \"' + condition.statement + '\": ' + err);
-            }
-            return cb(null, response);
-        }.bind(this));
-    };
+            return versionApi.cloneServiceVersion({service_id: serviceId, version_id: version});
+        },
 
-    /*
-     * setFastlyHeader: Upsert a Fastly header entry
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Header object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setFastlyHeader = function (version, header, cb) {
-        if (!this.serviceId) {
-            cb('Failed to set header. No serviceId configured');
-        }
-        var name = header.name;
-        var putUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/header/' + encodeURIComponent(name);
-        var postUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/header';
-        return this.request('PUT', putUrl, header, function (err, response) {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, header, function (err, response) {
-                    if (err) {
-                        return cb('Failed to insert header: ' + err);
-                    }
-                    return cb(null, response);
-                });
-                return;
+        // Upsert a Fastly condition entry.
+        setCondition: (version, condition) => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to set condition. No serviceId configured'));
             }
-            if (err) {
-                return cb('Failed to update header: ' + err);
+            const params = withService(version, condition);
+            return upsert(
+                () => conditionApi.updateCondition(Object.assign({condition_name: condition.name}, params)),
+                () => conditionApi.createCondition(params)
+            );
+        },
+
+        // Upsert a Fastly header entry.
+        setFastlyHeader: (version, header) => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to set header. No serviceId configured'));
             }
-            return cb(null, response);
-        }.bind(this));
-    };
+            const params = withService(version, header);
+            return upsert(
+                () => headerApi.updateHeaderObject(Object.assign({header_name: header.name}, params)),
+                () => headerApi.createHeaderObject(params)
+            );
+        },
 
-    /*
-     * setResponseObject: Upsert a Fastly response object
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Response object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setResponseObject = function (version, responseObj, cb) {
-        if (!this.serviceId) {
-            cb('Failed to set response object. No serviceId configured');
-        }
-        var name = responseObj.name;
-        var putUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/response_object/' + encodeURIComponent(name);
-        var postUrl = this.getFastlyAPIPrefix(this.serviceId, version) + '/response_object';
-        return this.request('PUT', putUrl, responseObj, function (err, response) {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, responseObj, function (err, response) {
-                    if (err) {
-                        return cb('Failed to insert response object: ' + err);
-                    }
-                    return cb(null, response);
-                });
-                return;
+        // Upsert a Fastly response object. The client takes the body wrapped in
+        // create_response_object_request for both create and update.
+        setResponseObject: (version, responseObject) => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to set response object. No serviceId configured'));
             }
-            if (err) {
-                return cb('Failed to update response object: ' + err);
+            return upsert(
+                () => responseObjectApi.updateResponseObject(withService(version, {
+                    response_object_name: responseObject.name,
+                    create_response_object_request: responseObject
+                })),
+                () => responseObjectApi.createResponseObject(withService(version, {
+                    create_response_object_request: responseObject
+                }))
+            );
+        },
+
+        // Activate a version.
+        activateVersion: version => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to activate version. No serviceId configured.'));
             }
-            return cb(null, response);
-        }.bind(this));
-    };
+            return versionApi.activateServiceVersion({service_id: serviceId, version_id: version});
+        },
 
-    /*
-     * cloneVersion: Clone a version to create a new version
-     *
-     * @param {number} Version to clone
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.cloneVersion = function (version, cb) {
-        if (!this.serviceId) return cb('Failed to clone version. No serviceId configured.');
-        var url = this.getFastlyAPIPrefix(this.serviceId, version) + '/clone';
-        this.request('PUT', url, cb);
+        // Purge all content for a service.
+        purgeAll: servId => purgeApi.purgeAll({service_id: servId})
     };
-
-    /*
-     * activateVersion: Activate a version
-     *
-     * @param {number} Version number
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.activateVersion = function (version, cb) {
-        if (!this.serviceId) return cb('Failed to activate version. No serviceId configured.');
-        var url = this.getFastlyAPIPrefix(this.serviceId, version) + '/activate';
-        this.request('PUT', url, cb);
-    };
-
-    return fastly;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-json": "1.2.0",
         "eslint-plugin-react": "7.5.1",
         "express": "4.17.1",
-        "fastly": "2.2.0",
+        "fastly": "15.1.0",
         "html-loader": "5.1.0",
         "html-webpack-plugin": "5.6.4",
         "lodash.debounce": "4.0.8",
@@ -3351,24 +3351,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3382,7 +3364,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -3436,21 +3419,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true
     },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
@@ -3629,15 +3597,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -3665,19 +3624,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -3837,12 +3783,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ==",
-      "dev": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4013,6 +3953,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4025,6 +3966,16 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4091,6 +4042,13 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "13.0.1",
@@ -4278,19 +4236,6 @@
         "which": "^1.2.9"
       }
     },
-    "node_modules/cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
-      "dependencies": {
-        "boom": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/css-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
@@ -4465,27 +4410,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/dashdash/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4597,6 +4521,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4728,16 +4653,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dev": true,
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -5655,12 +5570,6 @@
         "type": "^2.7.2"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "node_modules/external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -5674,15 +5583,6 @@
       "engines": {
         "node": ">=0.12"
       }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "1.1.0",
@@ -5701,6 +5601,13 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -5730,15 +5637,13 @@
       }
     },
     "node_modules/fastly": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fastly/-/fastly-2.2.0.tgz",
-      "integrity": "sha512-f+MPFr7I6hjcJSTMrx9jx5drGW9gsKq7Wc4xS3k2fMbZOCowXA2BGfe8uS1KSAqZXT3+kkWdnNhu3U29uGzlnw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/fastly/-/fastly-15.1.0.tgz",
+      "integrity": "sha512-qHZBEJfjAoPqVCNOQLOKrdZY8aSr/AdVET9/uK951+oSlW5We+l9v88IqxpeUyAZygOIKoFS+MnLI19iDPmBDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "request": "~2.79.0"
-      },
-      "engines": {
-        "node": ">=0.10"
+        "superagent": "^6.1.0"
       }
     },
     "node_modules/fbjs": {
@@ -5915,27 +5820,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -6123,24 +6033,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/getpass/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6289,59 +6181,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha512-P6tFV+wCcUL3nbyTDAvveDySfbhy0XkDtAIfZP6HITjM2WUsiPna/Eg1Yy93SFXvahqoX+kt0n+6xlXKDXYowA==",
-      "deprecated": "this library is no longer supported",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "is-my-json-valid": "^2.12.4",
-        "pinkie-promise": "^2.0.0"
-      },
-      "bin": {
-        "har-validator": "bin/har-validator"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/har-validator/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/har-validator/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/har-validator/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
@@ -6450,22 +6289,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==",
-      "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
-      "dev": true,
-      "dependencies": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -6488,16 +6311,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.40"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -6695,21 +6508,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true
-    },
-    "node_modules/http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha512-iUn0NcRULlDGtqNLN1Jxmzayk8ogm7NToldASyZBpM2qggbphjXzNOiw3piN8tgz+e/DRs6X5gAzFwTI6BCRcg==",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^0.2.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
@@ -7302,12 +7100,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -7381,12 +7173,6 @@
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -7484,12 +7270,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
-    },
     "node_modules/jshint": {
       "version": "2.13.6",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.6.tgz",
@@ -7545,12 +7325,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -7588,12 +7362,6 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "node_modules/json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -7619,30 +7387,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/jsprim/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8230,15 +7974,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8636,27 +8371,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "dev": true,
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8991,12 +8705,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
     },
     "node_modules/qs": {
@@ -9463,47 +9171,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha512-e7MIJshe1eZAmRqg4ryaO0N9G0fs+/gpDe5FlbnIFy6zZznRSwdRFrLp63if0Yt43vrI5wowOqHv1qJdVocdOQ==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "aws-sign2": "~0.6.0",
-        "aws4": "^1.2.1",
-        "caseless": "~0.11.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.0",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.1.1",
-        "har-validator": "~2.0.6",
-        "hawk": "~3.1.3",
-        "http-signature": "~1.1.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.7",
-        "oauth-sign": "~0.8.1",
-        "qs": "~6.3.0",
-        "stringstream": "~0.0.4",
-        "tough-cookie": "~2.3.0",
-        "tunnel-agent": "~0.4.1",
-        "uuid": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.5.tgz",
-      "integrity": "sha512-XHYh9odu8o3MF7tPfaCo0B3famGArheKb6L4PmXhfsqitUPO817bdFkDDANnE6tEYVe9/g7yu9OWJOSBYGEzKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/require-from-string": {
@@ -10491,19 +10158,6 @@
         "jquery": ">=1.8.0"
       }
     },
-    "node_modules/sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==",
-      "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
-      "dev": true,
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10529,40 +10183,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "dev": true,
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sshpk/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -10731,12 +10351,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
-    },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -10773,6 +10387,113 @@
       },
       "peerDependencies": {
         "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">= 7.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/superagent/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -10936,18 +10657,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.4.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tree-dump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
@@ -10971,21 +10680,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha512-e0IoVDWx8SDHc/hwFTqJDQ7CCDTEeGhmcT9jkWJjoGQSpgBz20nAMr80E3Tpk7PatJ1b37DQDgJR3CNSzcMOZQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -11291,16 +10985,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -11315,35 +10999,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
     },
     "node_modules/warning": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-react": "7.5.1",
     "express": "4.17.1",
-    "fastly": "2.2.0",
+    "fastly": "15.1.0",
     "html-loader": "5.1.0",
     "html-webpack-plugin": "5.6.4",
     "lodash.debounce": "4.0.8",


### PR DESCRIPTION
### Proposed Changes

- Replace the unmaintained `fastly@2.2.0` (thisandagain) client with the official `fastly@15` (fastly-js).
- Rewrite `bin/lib/fastly-extended.js` to wrap the official per-resource API classes (Version/Condition/Header/ResponseObject/Purge), keeping the same promise-returning, upsert-by-name helper signatures.
- Drop the `util.promisify` shims in `bin/configure-fastly.js`; call the now promise-native helpers directly.
- Modernize both files to `const`/`let`, arrow functions, and template literals.

### Reason for Changes

- `fastly@2.2.0` is unmaintained and callback-based. The official fastly-js client is promise-native, maintained, and covers the full API (including VCL snippets, which the follow-up redirect-config rework will use).
- Removes the deprecated `request`-based dependency subtree.

### Test Coverage

- Behavior-preserving: the same conditions, headers, and response objects are created.
- Verified locally: `node --check`, `eslint --no-ignore` clean, and a smoke test (module loads, authenticates, and a missing-service error propagates through the script's `.catch`).
- Not yet exercised against a live Fastly service: the create/update API calls, the 404-upsert fallback, and param shapes should be confirmed on a staging deploy.
- One behavior change: `authenticate()` fails fast at startup if `FASTLY_API_KEY` is unset, rather than deferring to the first API call.
